### PR TITLE
Fix typo in require json_mysql => json-mysql

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 ```
 // From JSON:
 
-const json_mysql = require("json_mysql");
+const json_mysql = require("json-mysql");
 
 let test_json = {
   symbol: "BNBUSDT",


### PR DESCRIPTION
I installed the package and ran the 'How to Use' code without double checking only to face an error.
Turns out the wrong package name is being required.